### PR TITLE
Add python-tzdata as a runtime requirement

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,6 +24,7 @@ requirements:
     - python >={{ python_min }}
     - aeventkit >=2.1.0
     - nest-asyncio
+    - python-tzdata >=2025.2
 
 test:
   imports:


### PR DESCRIPTION
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

There are two different conda-forge packages related to `tzdata`:

+ tzdata on conda-forge is a separate data/system package that provides the raw IANA tzdb files for non-Python consumers and does not provide the Python distribution/metadata that Python packages expect.
+ python-tzdata is the conda-forge package that packages the PyPI tzdata distribution for Python (i.e. what pip installs as tzdata) and installs the Python package into site-packages so Python code / PEP 615 zoneinfo/backports.zoneinfo can find it.

**@sanurielf, I would like to volunteer to be an additional maintainer of this feedstock, if you're willing to add me.**